### PR TITLE
Add json response support

### DIFF
--- a/nsxramlclient/http_session.py
+++ b/nsxramlclient/http_session.py
@@ -27,6 +27,7 @@ from collections import OrderedDict
 import xmloperations
 from lxml import etree as et
 import OpenSSL.SSL
+import json
 
 
 def retry(catchexception, tries=4, wait=3, backofftime=2):
@@ -108,6 +109,8 @@ class Session(object):
         elif 'content-type' in response.headers:
             if response.headers['content-type'].find('application/xml') != -1:
                 response_content = xmloperations.xml_to_dict(et.fromstring(response.content))
+            elif response.headers['content-type'].find('application/json') != -1:
+                response_content = json.loads(response.content)
             else:
                 response_content = response.content
 


### PR DESCRIPTION
NSX Manager might return a response of json(e.g. globalInfo). 
Add json response support.

The difference will appear in the following execution
```
res = client_session.read('globalInfo')
print type(res['body'])
```
before outputs: `<type 'string'>`
after outputs : `<type dict'>`