### PR TITLE
Fix Python 2/3 compatibility + Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 *.pyc
 secret.yml
+.tox/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+generated-members=requests.packages.urllib3

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [TYPECHECK]
 generated-members=requests.packages.urllib3
+ignored-modules = distutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+cache: pip
+sudo: false
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
+# xenial required for python3.7+:
+# https://docs.travis-ci.com/user/languages/python/#python-37-and-higher
+dist: xenial
 cache: pip
 sudo: false
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/nsxramlclient/client.py
+++ b/nsxramlclient/client.py
@@ -24,8 +24,8 @@ import pprint
 import pyraml.parser
 from lxml import etree as et
 
-import http_session
-import xmloperations
+from . import http_session
+from . import xmloperations
 
 
 class NsxClient(object):
@@ -173,20 +173,20 @@ class NsxClient(object):
 
     def view_resource_body_schema(self, searched_resource, method):
         xml_schema_result = self._nsxraml.get_xml_schema_by_displayname(searched_resource, method)
-        print et.tostring(xml_schema_result, pretty_print=True)
+        print(et.tostring(xml_schema_result, pretty_print=True))
 
     def view_resource_body_example(self, searched_resource, method, remove_content=None, remove_comments=None):
         xml_schema_result = self._nsxraml.get_xml_example_by_displayname(searched_resource, method,
                                                                          remove_comments=remove_comments,
                                                                          remove_content=remove_content)
-        print et.tostring(xml_schema_result, pretty_print=True)
+        print(et.tostring(xml_schema_result, pretty_print=True))
 
     def extract_resource_body_schema(self, searched_resource, method):
         # NOTE: THis method is deprecated and will be removed in future version
         xml_schema_result = self._nsxraml.get_xml_schema_by_displayname(searched_resource, method)
-        print '\033[91m' + "DEPRECATION WARNING: This method is deprecated in nsxramlclient v2.x and " \
+        print('\033[91m' + "DEPRECATION WARNING: This method is deprecated in nsxramlclient v2.x and " \
                            "will be removed in future.\nPlease start using the method extract_resource_body_example " \
-                           "instead.\nThis method does not support the NSXv 6.2.4 and later RAML specs" + '\033[0m'
+                           "instead.\nThis method does not support the NSXv 6.2.4 and later RAML specs" + '\033[0m')
         return xmloperations.xml_to_dict(xml_schema_result)
 
     def extract_resource_body_example(self, searched_resource, method, remove_content=None, remove_comments=None):
@@ -198,15 +198,15 @@ class NsxClient(object):
     @staticmethod
     def view_response(ordered_dict):
         pretty_printer = pprint.PrettyPrinter()
-        print 'HTTP status code:\n{}\n'.format(ordered_dict['status'])
+        print('HTTP status code:\n{}\n'.format(ordered_dict['status']))
         if ordered_dict['location']:
-            print 'HTTP location header:\n{}\n'.format(ordered_dict['location'])
+            print('HTTP location header:\n{}\n'.format(ordered_dict['location']))
         if ordered_dict['objectId']:
-            print 'NSX Object Id:\n{}\n'.format(ordered_dict['objectId'])
+            print('NSX Object Id:\n{}\n'.format(ordered_dict['objectId']))
         if ordered_dict['Etag']:
-            print 'Etag Header:\n{}\n'.format(ordered_dict['Etag'])
+            print('Etag Header:\n{}\n'.format(ordered_dict['Etag']))
         if ordered_dict['body']:
-            print 'HTTP Body Content:'
+            print('HTTP Body Content:')
             pretty_printer.pprint(ordered_dict['body'])
 
     @staticmethod
@@ -229,14 +229,14 @@ class NsxClient(object):
 
             output_text.append('\n')
 
-        print ''.join(output_text)
+        print(''.join(output_text))
 
     def read_all_pages(self, searched_resource, uri_parameters=None, request_body_dict=None,
                        query_parameters_dict=None, additional_headers=None):
         supported_objects = ['virtualWires', 'pagedEdgeList']
         first_page = self._request(searched_resource, 'get', uri_parameters, request_body_dict, query_parameters_dict,
                                    additional_headers)['body']
-        first_key = first_page.keys()[0]
+        first_key = list(first_page.keys())[0]
         assert first_key in supported_objects, 'unsupported object {}, currently only {} ' \
                                                'are supported'.format(first_key, supported_objects)
 
@@ -313,9 +313,9 @@ class NsxRaml(object):
         # this method runs through the base raml file recursively until it finds the first
         # occurrence of the searched displayName in the resource
         if raml_resource_root:
-            searched_tuples = raml_resource_root.resources.items()
+            searched_tuples = list(raml_resource_root.resources.items())
         else:
-            searched_tuples = self._nsxraml.resources.items()
+            searched_tuples = list(self._nsxraml.resources.items())
 
         for resource_tuple in searched_tuples:
             if resource_tuple[1].displayName == str(display_name):
@@ -339,7 +339,7 @@ class NsxRaml(object):
                 raise Exception('one of the passed URI parameter could not be found in RAMl File')
 
             for uri_parameter in resource_uri_params:
-                assert uri_parameter in uri_parameters.keys(), \
+                assert uri_parameter in list(uri_parameters.keys()), \
                     'one required URI parameter is missing in the passed URI parameters, ' \
                     'required parameters are {}'.format(resource_uri_params)
                 resource_url = re.sub('\{' + uri_parameter + '\}', uri_parameters[uri_parameter], resource_url)
@@ -377,27 +377,27 @@ class NsxRaml(object):
     def get_method_mandatory_query_parameters(self, display_name, method):
         found_res_object = self.find_resource_recursively(display_name)
         if found_res_object[1].methods[method].queryParameters:
-            return [parameter for parameter in found_res_object[1].methods[method].queryParameters.keys() if
+            return [parameter for parameter in list(found_res_object[1].methods[method].queryParameters.keys()) if
                     found_res_object[1].methods[method].queryParameters[parameter].required]
 
     def get_method_mandatory_add_headers(self, display_name, method):
         found_res_object = self.find_resource_recursively(display_name)
         if found_res_object[1].methods[method].headers:
-            return [header for header in found_res_object[1].methods[method].headers.keys() if
+            return [header for header in list(found_res_object[1].methods[method].headers.keys()) if
                     found_res_object[1].methods[method].headers[header].required]
 
     def add_query_parameter_url(self, url, display_name, method, query_parameters_dict):
         found_res_object = self.find_resource_recursively(display_name)
         mandatory_query_parameters = [parameter for parameter in
-                                      found_res_object[1].methods[method].queryParameters.keys() if
+                                      list(found_res_object[1].methods[method].queryParameters.keys()) if
                                       found_res_object[1].methods[method].queryParameters[parameter].required]
         missing_mandatory_qparameters = [parameter for parameter in mandatory_query_parameters if
-                                         parameter not in query_parameters_dict.keys()]
+                                         parameter not in list(query_parameters_dict.keys())]
         assert len(missing_mandatory_qparameters) == 0, 'Missing required query ' \
                                                         'parameters : {}'.format(missing_mandatory_qparameters)
 
         url = '{}?'.format(url)
-        for query_parameter in query_parameters_dict.keys():
+        for query_parameter in list(query_parameters_dict.keys()):
             url = '{}&{}={}'.format(url, query_parameter, query_parameters_dict[query_parameter])
         return url
 
@@ -419,7 +419,7 @@ class NsxRaml(object):
         if isinstance(matched_resource_body['application/xml'].schema, base_et_element):
             return matched_resource_body['application/xml'].schema
         elif isinstance(matched_resource_body['application/xml'].schema, str):
-            assert matched_resource_body['application/xml'].schema in self._nsxraml.schemas.keys(), \
+            assert matched_resource_body['application/xml'].schema in list(self._nsxraml.schemas.keys()), \
                 'the external schema {} could not be found in the schema list of the RAML File'.format(
                     matched_resource_body['application/xml'].schema)
             assert isinstance(self._nsxraml.schemas[matched_resource_body['application/xml'].schema],
@@ -463,18 +463,18 @@ class NsxRaml(object):
         method_options = {'read': 'get', 'create': 'post', 'delete': 'delete', 'update': 'put'}
         if resource_tuple[1].methods:
             supported_methods = [key for key in resource_tuple[1].methods]
-            supported_operations = [operation[0] for operation in method_options.items()
+            supported_operations = [operation[0] for operation in list(method_options.items())
                                     if operation[1] in supported_methods]
-            method_items = [method_item for method_item in resource_tuple[1].methods.items()]
+            method_items = [method_item for method_item in list(resource_tuple[1].methods.items())]
 
             try:
-                query_parameters = [rmethod[1].queryParameters.keys() for rmethod in method_items if
+                query_parameters = [list(rmethod[1].queryParameters.keys()) for rmethod in method_items if
                                     rmethod[1].queryParameters][0]
             except IndexError:
                 query_parameters = None
 
             try:
-                resource_add_headers = [rmethod[1].headers.keys() for rmethod in method_items if
+                resource_add_headers = [list(rmethod[1].headers.keys()) for rmethod in method_items if
                                         rmethod[1].headers][0]
             except IndexError:
                 resource_add_headers = None
@@ -502,9 +502,9 @@ class NsxRaml(object):
             display_names_dict = {}
 
         if raml_resource_root:
-            scanned_tuples = raml_resource_root.resources.items()
+            scanned_tuples = list(raml_resource_root.resources.items())
         else:
-            scanned_tuples = self._nsxraml.resources.items()
+            scanned_tuples = list(self._nsxraml.resources.items())
 
         for resource_tuple in scanned_tuples:
             if resource_tuple[1].resources:

--- a/nsxramlclient/http_session.py
+++ b/nsxramlclient/http_session.py
@@ -23,14 +23,14 @@ import sys
 import time
 from functools import wraps
 from collections import OrderedDict
-from exceptions import NsxError
+from .exceptions import NsxError
 
 import requests
 from lxml import etree as et
 import OpenSSL.SSL
 import json
 
-import xmloperations
+from . import xmloperations
 
 
 def retry(catchexception, tries=4, wait=3, backofftime=2):
@@ -42,8 +42,8 @@ def retry(catchexception, tries=4, wait=3, backofftime=2):
             while innertries > 1:
                 try:
                     return f(*args, **kwargs)
-                except catchexception, e:
-                    print 'Error {} occured, retry in {} seconds'.format(str(e), innerwait)
+                except catchexception as e:
+                    print(('Error {} occured, retry in {} seconds'.format(str(e), innerwait)))
                     time.sleep(innerwait)
                     innerwait *= backofftime
                     innertries -= 1
@@ -67,8 +67,8 @@ class Session(object):
 
         # if debug then enable underlying httplib debugging
         if self._debug:
-            import httplib
-            httplib.HTTPConnection.debuglevel = 1
+            import http.client
+            http.client.HTTPConnection.debuglevel = 1
 
         # if suppress_warnings then disable any InsecureRequestWarnings caused by self signed certs
         if self._suppress_warnings:
@@ -94,7 +94,7 @@ class Session(object):
                 headers = {'Content-Type': 'application/xml'}
 
             if self._debug:
-                print md.parseString(data).toprettyxml()
+                print((md.parseString(data).toprettyxml()))
 
         response = self._session.request(method, url, headers=headers, params=params, data=data)
 

--- a/nsxramlclient/http_session.py
+++ b/nsxramlclient/http_session.py
@@ -67,8 +67,8 @@ class Session(object):
 
         # if debug then enable underlying httplib debugging
         if self._debug:
-            import http.client
-            http.client.HTTPConnection.debuglevel = 1
+            from six.moves import http_client
+            http_client.HTTPConnection.debuglevel = 1
 
         # if suppress_warnings then disable any InsecureRequestWarnings caused by self signed certs
         if self._suppress_warnings:

--- a/nsxramlclient/xmloperations.py
+++ b/nsxramlclient/xmloperations.py
@@ -36,11 +36,11 @@ def xml_to_dict(etree_object):
     if children:
         dd = defaultdict(list)
         for dc in map(xml_to_dict, children):
-            for k, v in dc.iteritems():
+            for k, v in dc.items():
                 dd[k].append(v)
-        return_dict = {etree_object.tag: {k: v[0] if len(v) == 1 else v for k, v in dd.iteritems()}}
+        return_dict = {etree_object.tag: {k: v[0] if len(v) == 1 else v for k, v in dd.items()}}
     if etree_object.attrib:
-        return_dict[etree_object.tag].update(('@' + k, v) for k, v in etree_object.attrib.iteritems())
+        return_dict[etree_object.tag].update(('@' + k, v) for k, v in etree_object.attrib.items())
     if etree_object.text:
         text = etree_object.text.strip()
         if children or etree_object.attrib:
@@ -60,7 +60,7 @@ def dict_to_xml(dict_to_parse):
 
 
 def parse_dict(xml_root_object, dict_to_parse):
-    for subitem in dict_to_parse.items():
+    for subitem in list(dict_to_parse.items()):
         # subitem is now a tuple of key, value in the dict
         xml_subitem_name = subitem[0]
         if type(subitem[1]) in (str, int, None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.7.0
 lxml
 pyraml-parser>=0.1.3
+six

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = read('README.rst')
 
 setup(
     name='nsxramlclient',
-    version='2.0.7',
+    version='2.0.8',
     packages=['nsxramlclient'],
     url='http://github.com/vmware/nsxramlclient',
     license='MIT',
@@ -29,5 +29,5 @@ setup(
     'Topic :: Software Development :: Libraries',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 2.7'],
-    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=3.6.0', 'requests>=2.7.0']
+    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.3.3', 'requests>=2.7.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     'Topic :: Software Development :: Libraries',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 2.7'],
-    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.3.3', 'requests>=2.7.0']
+    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.3.3', 'requests>=2.7.0', 'six']
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
 __author__ = 'yfauser'
+
+from __future__ import print_function

--- a/tests/dfw.py
+++ b/tests/dfw.py
@@ -55,7 +55,7 @@ def readByFilters():
 def readByIds():
 
     l3_dfw_by_section_id = client_session.read('dfwL3SectionId', uri_parameters={'sectionId': '1300'})
-    print l3_dfw_by_section_id
+    print(l3_dfw_by_section_id)
     client_session.view_response(l3_dfw_by_section_id)
 
     l2_dfw_by_section_id = client_session.read('dfwL2SectionId', uri_parameters={'sectionId': '1014'})

--- a/tests/logicalswitch_read.py
+++ b/tests/logicalswitch_read.py
@@ -44,8 +44,8 @@ try:
     new_ls_props = client_session.read('logicalSwitch', uri_parameters={'virtualWireID': lswitch_id2})
     client_session.view_response(new_ls_props)
 except NsxError as e:
-    print "### caught exception !!!!"
-    print e.status, e.msg
+    print("### caught exception !!!!")
+    print(e.status, e.msg)
 
 
 # Try to read properties using a invalid virtual wire Id
@@ -53,5 +53,5 @@ try:
     new_ls_props = client_session.read('logicalSwitch', uri_parameters={'virtualWireID': lswitch_id3})
     client_session.view_response(new_ls_props)
 except NsxError as e:
-    print "### caught exception !!!!"
-    print e.status, e.msg
+    print("### caught exception !!!!")
+    print(e.status, e.msg)

--- a/tests/nat.py
+++ b/tests/nat.py
@@ -17,6 +17,7 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from six.moves import input
 from tests.config import *
 from nsxramlclient.client import NsxClient
 
@@ -99,7 +100,7 @@ def main():
     append_nat(session)
     query_nat(session)
 
-    rule_id = raw_input('Enter RuleID as seen in above output: ')
+    rule_id = input('Enter RuleID as seen in above output: ')
     update_nat(session, rule_id)
     delete_nat(session)
 

--- a/tests/nwfabric.py
+++ b/tests/nwfabric.py
@@ -23,5 +23,5 @@ from nsxramlclient.client import NsxClient
 
 client_session = NsxClient(nsxraml_file, nsxmanager, nsx_username, nsx_password, debug=True)
 
-print client_session.read('nwfabricFeatures')
-print client_session.read('nwfabricStatus', query_parameters_dict={'resource': 'domain-c1632'})
+print(client_session.read('nwfabricFeatures'))
+print(client_session.read('nwfabricStatus', query_parameters_dict={'resource': 'domain-c1632'}))

--- a/tests/security_policy.py
+++ b/tests/security_policy.py
@@ -22,6 +22,7 @@
 
 __author__ = 'yfauser'
 
+from six.moves import input
 from tests.config import *
 from nsxramlclient.client import NsxClient
 from distutils.util import strtobool
@@ -32,7 +33,7 @@ def user_yes_no_query(question):
     sys.stdout.write('%s [y/n]\n' % question)
     while True:
         try:
-            return strtobool(raw_input().lower())
+            return strtobool(input().lower())
         except ValueError:
             sys.stdout.write('Please respond with \'y\' or \'n\'.\n')
 

--- a/tests/securitygroups.py
+++ b/tests/securitygroups.py
@@ -124,7 +124,7 @@ def main():
     get_sec_group_valid_types(s)
 
     new_sec_group = empty_sec_group_create(s, 'newSecGroup')
-    print new_sec_group
+    print(new_sec_group)
 
     sec_group_add_member(s, new_sec_group, '503bfba4-007b-0c27-aac7-26c71c1cbcff.000')
     get_all_sec_groups(s)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist = py27,
     py35,
-    py36
+    py36,
+    py37
 
 [testenv]
 deps = pylint
@@ -19,3 +20,6 @@ basepython=python3.5
 
 [testenv:py36]
 basepython=python3.6
+
+[testenv:py37]
+basepython=python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27,
+    py35,
+    py36
+
+[testenv]
+deps = pylint
+       -rrequirements.txt
+
+commands =
+    pylint --errors-only nsxramlclient
+    pylint --errors-only tests
+
+[testenv:py27]
+basepython=python2.7
+
+[testenv:py35]
+basepython=python3.5
+
+[testenv:py36]
+basepython=python3.6


### PR DESCRIPTION
This PR is inspired by #25 and other fixes in the https://github.com/FidelityInternational/nsxramlclient fork. I extended @combor existing work with:
- making sure the python3 fixes are backwards compatible with python2,
- adding tox+travis to run pylint, to at least prove there are no syntax errors.

See https://travis-ci.com/mzagozen/nsxramlclient/builds/110756752 for a successful result of the travis job. Essentially, pylint is run with `--errors-only` on python 2.7, 3.5, 3.6 and 3.7. Would be nice to have some unit tests too, but it's better than nothing XD

To the maintainers of this project - please activate Travis (free) for this repo after merging.